### PR TITLE
Bug Fix: Overlapping Islands in OceanScene

### DIFF
--- a/Scripts/ocean_scene.gd
+++ b/Scripts/ocean_scene.gd
@@ -93,19 +93,27 @@ func place_rocks(selected_squads):
 		rock_instance.position = center_pos * 16
 		add_child(rock_instance)
 
+
+func pick_random_large_squad():
+	
+	var random_index = randi() % all_large_squads.size()
+	var large_squad = all_large_squads[random_index]
+	return large_squad
+
 func place_random_island():
 	if all_large_squads.size() == 0 or islands.size() == 0:
 		print("No valid 16x16 squad or islands available!")
 		return
 
-	var random_index = randi() % all_large_squads.size()
-	var large_squad = all_large_squads[random_index]
-	var center_pos = calculate_center(large_squad)
-	var random_island_scene = islands[randi() % islands.size()]
-	var island_instance = random_island_scene.instantiate()
-	island_instance.position = center_pos * 16
-	add_child(island_instance)
-	mark_squad_as_contested(large_squad)
+	var large_squad = pick_random_large_squad()
+	
+	if is_squad_uncontested(large_squad):
+		var center_pos = calculate_center(large_squad)
+		var random_island_scene = islands[randi() % islands.size()]
+		var island_instance = random_island_scene.instantiate()
+		island_instance.position = center_pos * 16
+		add_child(island_instance)
+		mark_squad_as_contested(large_squad)
 
 func _input(event: InputEvent) -> void:
 	if event.is_action("Escape"):


### PR DESCRIPTION
- added uncontested check in island generation
- if an island would overlap with another, it is simply not placed
    - this introduces the possibility of only generating 1 or 2 islands instead of 3, but avoids potentially encountering an infinite loop when trying to place an island

Below, a 3rd island was going to overlap if placed & so hasn't been placed at all instead:

![image](https://github.com/user-attachments/assets/5f6c9b93-133e-4b7c-9676-f80506d22a79)
